### PR TITLE
dwi2mask: New algorithm "ants"

### DIFF
--- a/lib/mrtrix3/dwi2mask/ants.py
+++ b/lib/mrtrix3/dwi2mask/ants.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2008-2019 the MRtrix3 contributors.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Covered Software is provided under this License on an "as is"
+# basis, without warranty of any kind, either expressed, implied, or
+# statutory, including, without limitation, warranties that the
+# Covered Software is free of defects, merchantable, fit for a
+# particular purpose or non-infringing.
+# See the Mozilla Public License v. 2.0 for more details.
+#
+# For more details, see http://www.mrtrix.org/.
+
+import os
+from distutils.spawn import find_executable
+from mrtrix3 import MRtrixError
+from mrtrix3 import app, fsl, image, path, run
+
+def usage(base_parser, subparsers): #pylint: disable=unused-variable
+  parser = subparsers.add_parser('ants', parents=[base_parser])
+  parser.set_author('Robert E. Smith (robert.smith@florey.edu.au)')
+  parser.set_synopsis('Use ANTs Brain Extraction to derive a DWI brain mask')
+  parser.add_citation('B. Avants, N.J. Tustison, G. Song, P.A. Cook, A. Klein, J.C. Jee. A reproducible evaluation of ANTs similarity metric performance in brain image registration. NeuroImage, 2011, 54, 2033-2044', is_external=True)
+  parser.add_argument('input',  help='The input DWI series')
+  parser.add_argument('output', help='The output mask image')
+  options = parser.add_argument_group('Options specific to the "ants" algorithm')
+  options.add_argument('-template', metavar='TemplateImage MaskImage', nargs=2, help='Provide the template image and corresponding mask for antsBrainExtraction.sh to use; the template image should be T2-weighted.')
+
+
+
+def get_inputs(): #pylint: disable=unused-variable
+  if not app.ARGS.template:
+    raise MRtrixError('For "ants" dwi2mask algorithm, '
+                      '-template command-line option is currently mandatory')
+  run.command('mrconvert ' + app.ARGS.template[0] + ' ' + path.to_scratch('template_image.nii')
+              + ' -strides +1,+2,+3')
+  run.command('mrconvert ' + app.ARGS.template[1] + ' ' + path.to_scratch('template_mask.nii')
+              + ' -strides +1,+2,+3')
+
+
+
+def execute(): #pylint: disable=unused-variable
+  ants_path = os.environ.get('ANTSPATH', '')
+  if not ants_path:
+    raise MRtrixError('Environment variable ANTSPATH is not set; '
+                      'please appropriately confirure ANTs software')
+  ants_brain_extraction_cmd = find_executable('antsBrainExtraction.sh')
+  if not ants_brain_extraction_cmd:
+    raise MRtrixError('Unable to find command "'
+                      + ants_brain_extraction_cmd
+                      + '"; please check ANTs installation')
+
+  # Produce mean b=0 image
+  run.command('dwiextract input.mif -bzero - | '
+              'mrmath - mean - -axis 3 | '
+              'mrconvert - bzero.nii -strides +1,+2,+3')
+
+  run.command('antsBrainExtraction.sh '
+              + ' -d 3'
+              + ' -c 3x3x2x1'
+              + ' -a bzero.nii'
+              + ' -e ' + app.ARGS.template[0]
+              + ' -m ' + app.ARGS.template[1]
+              + ' -o out'
+              + ('' if app.DO_CLEANUP else ' -k 1')
+              + (' -z' if app.VERBOSITY >= 3 else ''))
+
+  strides = image.Header('input.mif').strides()[0:3]
+  strides = [(abs(value) + 1 - min(abs(v) for v in strides)) * (-1 if value < 0 else 1) for value in strides]
+
+  run.command('mrconvert outBrainExtractionMask.nii.gz '
+              + path.from_user(app.ARGS.output)
+              + ' -strides ' + ','.join(str(value) for value in strides),
+              mrconvert_keyval=path.from_user(app.ARGS.input, False),
+              force=app.FORCE_OVERWRITE)

--- a/lib/mrtrix3/dwi2mask/ants.py
+++ b/lib/mrtrix3/dwi2mask/ants.py
@@ -18,6 +18,10 @@ from distutils.spawn import find_executable
 from mrtrix3 import MRtrixError
 from mrtrix3 import app, fsl, image, path, run
 
+
+ANTS_BRAIN_EXTRACTION_CMD = 'antsBrainExtraction.sh'
+
+
 def usage(base_parser, subparsers): #pylint: disable=unused-variable
   parser = subparsers.add_parser('ants', parents=[base_parser])
   parser.set_author('Robert E. Smith (robert.smith@florey.edu.au)')
@@ -46,10 +50,9 @@ def execute(): #pylint: disable=unused-variable
   if not ants_path:
     raise MRtrixError('Environment variable ANTSPATH is not set; '
                       'please appropriately confirure ANTs software')
-  ants_brain_extraction_cmd = find_executable('antsBrainExtraction.sh')
-  if not ants_brain_extraction_cmd:
+  if not find_executable(ANTS_BRAIN_EXTRACTION_CMD):
     raise MRtrixError('Unable to find command "'
-                      + ants_brain_extraction_cmd
+                      + ANTS_BRAIN_EXTRACTION_CMD
                       + '"; please check ANTs installation')
 
   # Produce mean b=0 image
@@ -57,7 +60,7 @@ def execute(): #pylint: disable=unused-variable
               'mrmath - mean - -axis 3 | '
               'mrconvert - bzero.nii -strides +1,+2,+3')
 
-  run.command('antsBrainExtraction.sh '
+  run.command(ANTS_BRAIN_EXTRACTION_CMD
               + ' -d 3'
               + ' -c 3x3x2x1'
               + ' -a bzero.nii'

--- a/lib/mrtrix3/dwi2mask/template.py
+++ b/lib/mrtrix3/dwi2mask/template.py
@@ -169,7 +169,7 @@ def execute(): #pylint: disable=unused-variable
   # Instead of neaerest-neighbour interpolation during transformation,
   #   apply a threshold of 0.5 at this point
   run.command('mrthreshold '
-              + mask_path
+              + transformed_path
               + ' mask.mif -abs 0.5')
 
   # Make relative strides of three spatial axes of output mask equivalent

--- a/lib/mrtrix3/dwi2mask/template.py
+++ b/lib/mrtrix3/dwi2mask/template.py
@@ -69,10 +69,15 @@ def execute(): #pylint: disable=unused-variable
     if not ants_path:
       raise MRtrixError('Environment variable ANTSPATH is not set; '
                         'please appropriately confirure ANTs software')
-    ants_brain_extraction_cmd = find_executable('antsBrainExtraction.sh')
-    if not ants_brain_extraction_cmd:
+    ants_register_cmd = find_executable('ANTS')
+    if not ants_register_cmd:
       raise MRtrixError('Unable to find command "'
-                        + ants_brain_extraction_cmd
+                        + ants_register_cmd
+                        + '"; please check ANTs installation')
+    ants_transform_cmd = find_executable('WarpImageMultiTransform')
+    if not ants_transform_cmd:
+      raise MRtrixError('Unable to find command "'
+                        + ants_transform_cmd
                         + '"; please check ANTs installation')
   elif reg_software == 'fsl':
     fsl_path = os.environ.get('FSLDIR', '')
@@ -98,17 +103,22 @@ def execute(): #pylint: disable=unused-variable
 
   if reg_software == 'ants':
 
-    run.command(ants_brain_extraction_cmd
-                + ' -d 3'
-                + ' -c 3x3x2x1'
-                + ' -a bzero.nii'
-                + ' -e ' + app.ARGS.template[0]
-                + ' -m ' + app.ARGS.template[1]
-                + ' -o out'
-                + ('' if app.DO_CLEANUP else ' -k 1')
-                + (' -z' if app.VERBOSITY >= 3 else ''))
-
-    mask_path = 'outBrainExtractionMask.nii.gz'
+    # Use ANTs SyN for registration to template
+    # From Klein et al., NeuroImage 2009:
+    run.command('ANTS 3 '
+                + '-m PR[template_image.nii, bzero.nii, 1, 2]'
+                + ' -o ANTS'
+                + ' -r Gauss[2,0]'
+                + ' -t SyN[0.5]'
+                + ' -i 30x99x11'
+                + ' --use-Histogram-Matching')
+    transformed_path = 'transformed.nii'
+    # Note: Don't use nearest-neighbour interpolation;
+    #   allow "partial volume fractions" in output, and threshold later
+    run.command('WarpImageMultiTransform 3 template_mask.nii '
+                + transformed_path
+                + ' -R bzero.nii'
+                + ' -i ANTSAffine.txt ANTSInverseWarp.nii')
 
   elif reg_software == 'fsl':
 
@@ -149,20 +159,18 @@ def execute(): #pylint: disable=unused-variable
                 + ' --ref=bzero.nii'
                 + ' --in=' + app.ARGS.template[1]
                 + ' --warp=' + invwarp_output_path
-                + ' --out=mask.nii')
-    applywarp_output_path = fsl.find_image('mask.nii')
+                + ' --out=transformed.nii')
+    transformed_path = fsl.find_image('transformed.nii')
 
-    # Instead of neaerest-neighbour interpolation during transformation,
-    #   apply a threshold of 0.5 at this point
-    mask_path = 'mask.mif'
-    run.command('mrthreshold '
-                + applywarp_output_path
-                + ' '
-                + mask_path
-                + ' -abs 0.5')
 
   else:
     assert False
+
+  # Instead of neaerest-neighbour interpolation during transformation,
+  #   apply a threshold of 0.5 at this point
+  run.command('mrthreshold '
+              + mask_path
+              + ' mask.mif -abs 0.5')
 
   # Make relative strides of three spatial axes of output mask equivalent
   #   to input DWI; this may involve decrementing magnitude of stride
@@ -170,9 +178,7 @@ def execute(): #pylint: disable=unused-variable
   strides = image.Header('input.mif').strides()[0:3]
   strides = [(abs(value) + 1 - min(abs(v) for v in strides)) * (-1 if value < 0 else 1) for value in strides]
 
-  run.command('mrconvert '
-              + mask_path
-              + ' '
+  run.command('mrconvert mask.mif '
               + path.from_user(app.ARGS.output)
               + ' -strides ' + ','.join(str(value) for value in strides),
               mrconvert_keyval=path.from_user(app.ARGS.input, False),


### PR DESCRIPTION
- Move usage of "`antsBrainExtraction.sh`" from `dwi2mask template -software ants` to `dwi2mask ants`

- In `dwi2mask template -software ants`, use basic registration to template image & transformation of template mask.