### PR TITLE
dwi2mask: Add config file options

### DIFF
--- a/bin/dwi2response
+++ b/bin/dwi2response
@@ -109,7 +109,8 @@ def execute(): #pylint: disable=unused-variable
       raise MRtrixError('Provided mask image needs to be a 3D image')
   else:
     app.console('Computing brain mask (dwi2mask)...')
-    run.command('dwi2mask dwi.mif mask.mif', show=False)
+    dwi2mask_algo = CONFIG.get('Dwi2maskAlgorithm', 'legacy')
+    run.command('dwi2mask ' + dwi2mask_algo + ' dwi.mif mask.mif', show=False)
 
   if not image.statistics('mask.mif', mask='mask.mif').count:
     raise MRtrixError(('Provided' if app.ARGS.mask else 'Generated') + ' mask image does not contain any voxels')

--- a/bin/dwifslpreproc
+++ b/bin/dwifslpreproc
@@ -728,7 +728,7 @@ def execute(): #pylint: disable=unused-variable
 
   # Need gradient table if running dwi2mask after applytopup to derive a brain mask for eddy
   run.command('mrinfo dwi.mif -export_grad_mrtrix grad.b')
-
+  dwi2mask_algo = CONFIG.get('Dwi2maskAlgorithm', 'legacy')
 
   eddy_in_topup_option = ''
   dwi_post_eddy_crop_option = ''
@@ -831,10 +831,11 @@ def execute(): #pylint: disable=unused-variable
 
     # Use the initial corrected volumes to derive a brain mask for eddy
     if not app.ARGS.eddy_mask:
+
       if len(applytopup_image_list) == 1:
-        run.command('dwi2mask ' + applytopup_image_list[0] + ' - | maskfilter - dilate - | mrconvert - eddy_mask.nii -datatype float32 -strides -1,+2,+3')
+        run.command('dwi2mask ' + dwi2mask_algo + ' ' + applytopup_image_list[0] + ' - | maskfilter - dilate - | mrconvert - eddy_mask.nii -datatype float32 -strides -1,+2,+3')
       else:
-        run.command('mrcat ' + ' '.join(applytopup_image_list) + ' - -axis 3 | dwi2mask - - | maskfilter - dilate - | mrconvert - eddy_mask.nii -datatype float32 -strides -1,+2,+3')
+        run.command('mrcat ' + ' '.join(applytopup_image_list) + ' - -axis 3 | dwi2mask ' + dwi2mask_algo + ' - - | maskfilter - dilate - | mrconvert - eddy_mask.nii -datatype float32 -strides -1,+2,+3')
 
     app.cleanup(applytopup_image_list)
 
@@ -844,7 +845,7 @@ def execute(): #pylint: disable=unused-variable
 
     # Generate a processing mask for eddy based on the uncorrected input DWIs
     if not app.ARGS.eddy_mask:
-      run.command('dwi2mask ' + dwi_path + ' - | maskfilter - dilate - | mrconvert - eddy_mask.nii -datatype float32 -strides -1,+2,+3')
+      run.command('dwi2mask ' + dwi2mask_algo + ' ' + dwi_path + ' - | maskfilter - dilate - | mrconvert - eddy_mask.nii -datatype float32 -strides -1,+2,+3')
 
 
   # Use user supplied mask for eddy instead of one derived from the images using dwi2mask

--- a/bin/dwigradcheck
+++ b/bin/dwigradcheck
@@ -35,7 +35,7 @@ def usage(cmdline): #pylint: disable=unused-variable
 
 
 def execute(): #pylint: disable=unused-variable
-  from mrtrix3 import MRtrixError #pylint: disable=no-name-in-module, import-outside-toplevel
+  from mrtrix3 import CONFIG, MRtrixError #pylint: disable=no-name-in-module, import-outside-toplevel
   from mrtrix3 import app, image, matrix, path, run #pylint: disable=no-name-in-module, import-outside-toplevel
 
   image_dimensions = image.Header(path.from_user(app.ARGS.input, False)).size()
@@ -87,7 +87,8 @@ def execute(): #pylint: disable=unused-variable
   # Note that gradient table must be explicitly loaded, since there may not
   #   be one in the image header (user may be relying on -grad or -fslgrad input options)
   if not os.path.exists('mask.mif'):
-    run.command('dwi2mask data.mif mask.mif -grad grad.b')
+    dwi2mask_algo = CONFIG.get('Dwi2maskAlgorithm', 'legacy')
+    run.command('dwi2mask ' + dwi2mask_algo + ' data.mif mask.mif -grad grad.b')
 
   # How many tracks are we going to generate?
   number_option = ' -select ' + str(app.ARGS.number)

--- a/core/file/pyconfig.h
+++ b/core/file/pyconfig.h
@@ -1,0 +1,61 @@
+/* Copyright (c) 2008-2020 the MRtrix3 contributors.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Covered Software is provided under this License on an "as is"
+ * basis, without warranty of any kind, either expressed, implied, or
+ * statutory, including, without limitation, warranties that the
+ * Covered Software is free of defects, merchantable, fit for a
+ * particular purpose or non-infringing.
+ * See the Mozilla Public License v. 2.0 for more details.
+ *
+ * For more details, see http://www.mrtrix.org/.
+ */
+
+#ifndef __file_pyconfig_h__
+#define __file_pyconfig_h__
+
+/* Config file options listed here so that they can be scraped by
+ * generate_user_docs.sh and added to the list of config file options in
+ * the documentation without modifying that script to read from the scripts
+ * directory.
+ */
+
+//CONF option: Dwi2maskAlgorithm
+//CONF default: legacy
+//CONF The dwi2mask algorithm to utilise whenever dwi2mask must be invoked
+//CONF within a Python script, and the user is not provided with the
+//CONF opportunity to select the algorithm at the command-line.
+
+//CONF option: Dwi2maskTemplateImage
+//CONF default: (none)
+//CONF The template image to utilise by default whenever the "dwi2mask ants"
+//CONF or "dwi2mask template" algorithms are invoked but no template image
+//CONF / mask pair are explicitly nominated at the command-line.
+
+//CONF option: Dwi2maskTemplateMask
+//CONF default: (none)
+//CONF The template brain mask to utilise by default whenever the "dwi2mask
+//CONF ants" or "dwi2mask template" algorithms are invoked but no template
+//CONF image / mask pair are explicitly nominated at the command-line.
+
+//CONF option: ScriptScratchDir
+//CONF default: `.`
+//CONF The location in which to generate the scratch directories to be
+//CONF used by MRtrix Python scripts. By default they will be generated
+//CONF in the working directory.
+//CONF Note that this setting does not influence the location in which
+//CONF piped images and other temporary files are created by MRtrix3;
+//CONF that is determined based on config file option :option:`TmpFileDir`.
+
+//CONF option: ScriptScratchPrefix
+//CONF default: `<script>-tmp-`
+//CONF The prefix to use when generating a unique name for a Python
+//CONF script scratch directory. By default the name of the invoked
+//CONF script itself will be used, followed by `-tmp-` (six random
+//CONF characters are then appended to produce a unique name in cases
+//CONF where a script may be run multiple times in parallel).
+
+#endif

--- a/core/file/pyconfig.h
+++ b/core/file/pyconfig.h
@@ -29,6 +29,11 @@
 //CONF within a Python script, and the user is not provided with the
 //CONF opportunity to select the algorithm at the command-line.
 
+//CONF option: Dwi2maskTemplateSoftware
+//CONF default: fsl
+//CONF The software to be used for registration and transformation
+//CONF by default within the "dwi2mask template" algorithm.
+
 //CONF option: Dwi2maskTemplateImage
 //CONF default: (none)
 //CONF The template image to utilise by default whenever the "dwi2mask ants"

--- a/core/file/utils.h
+++ b/core/file/utils.h
@@ -14,8 +14,8 @@
  * For more details, see http://www.mrtrix.org/.
  */
 
-#ifndef __file_ops_h__
-#define __file_ops_h__
+#ifndef __file_utils_h__
+#define __file_utils_h__
 
 #include <cstdint>
 #include <sys/types.h>
@@ -118,30 +118,6 @@ namespace MR
         static const std::string __tmpfile_prefix = __get_tmpfile_prefix();
         return __tmpfile_prefix;
       }
-
-
-      /* Config file options listed here so that they can be scraped by
-       * generate_user_docs.sh and added to the list of config file options in
-       * the documentation without modifying the script to read from the scripts
-       * directory.
-       */
-
-      //CONF option: ScriptScratchDir
-      //CONF default: `.`
-      //CONF The location in which to generate the scratch directories to be
-      //CONF used by MRtrix Python scripts. By default they will be generated
-      //CONF in the working directory.
-      //CONF Note that this setting does not influence the location in which
-      //CONF piped images and other temporary files are created by MRtrix3;
-      //CONF that is determined based on config file option :option:`TmpFileDir`.
-
-      //CONF option: ScriptScratchPrefix
-      //CONF default: `<script>-tmp-`
-      //CONF The prefix to use when generating a unique name for a Python
-      //CONF script scratch directory. By default the name of the invoked
-      //CONF script itself will be used, followed by `-tmp-` (six random
-      //CONF characters are then appended to produce a unique name in cases
-      //CONF where a script may be run multiple times in parallel).
 
     }
 

--- a/docs/fixel_based_analysis/mt_fibre_density_cross-section.rst
+++ b/docs/fixel_based_analysis/mt_fibre_density_cross-section.rst
@@ -71,7 +71,7 @@ Upsampling DWI data *before* computing FODs increases anatomical contrast and im
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Compute a whole brain mask from the upsampled DW images::
 
-    for_each * : dwi2mask IN/dwi_denoised_unringed_preproc_unbiased_upsampled.mif IN/dwi_mask_upsampled.mif
+    for_each * : dwi2mask legacy IN/dwi_denoised_unringed_preproc_unbiased_upsampled.mif IN/dwi_mask_upsampled.mif
 
 .. WARNING:: It is absolutely **crucial** to check at this stage that *all* individual subject masks include *all* regions of the brain that are intended to be analysed. Fibre orientation distributions will *only* be computed within these masks; and at a later step (in template space) the analysis mask will be restricted to the *intersection* of all masks, so *any* individual subject mask which excludes a certain region, will result in this region being excluded from the entire analysis (unless a more advanced pipeline is followed; see :ref:`mitigating_brain_cropping`). Masks appearing too generous or otherwise including non-brain regions should generally not cause any concerns at this stage. Hence, if in doubt, it is advised to always err on the side of *inclusion* (of regions) at this stage.
 

--- a/docs/fixel_based_analysis/st_fibre_density_cross-section.rst
+++ b/docs/fixel_based_analysis/st_fibre_density_cross-section.rst
@@ -40,7 +40,7 @@ Pre-processsing steps
 
 Compute a brain mask::
 
-    for_each * : dwi2mask IN/dwi_denoised_preproc.mif IN/dwi_temp_mask.mif
+    for_each * : dwi2mask legacy IN/dwi_denoised_preproc.mif IN/dwi_temp_mask.mif
 
 
 AFD-specific pre-processsing steps

--- a/docs/reference/config_file_options.rst
+++ b/docs/reference/config_file_options.rst
@@ -237,6 +237,13 @@ List of MRtrix3 configuration file options
      ants" or "dwi2mask template" algorithms are invoked but no template
      image / mask pair are explicitly nominated at the command-line.
 
+.. option:: Dwi2maskTemplateSoftware
+
+    *default: fsl*
+
+     The software to be used for registration and transformation
+     by default within the "dwi2mask template" algorithm.
+
 .. option:: FailOnWarn
 
     *default: 0 (false)*

--- a/docs/reference/config_file_options.rst
+++ b/docs/reference/config_file_options.rst
@@ -213,6 +213,30 @@ List of MRtrix3 configuration file options
 
      The default intensity for the diffuse light in OpenGL renders.
 
+.. option:: Dwi2maskAlgorithm
+
+    *default: legacy*
+
+     The dwi2mask algorithm to utilise whenever dwi2mask must be invoked
+     within a Python script, and the user is not provided with the
+     opportunity to select the algorithm at the command-line.
+
+.. option:: Dwi2maskTemplateImage
+
+    *default: (none)*
+
+     The template image to utilise by default whenever the "dwi2mask ants"
+     or "dwi2mask template" algorithms are invoked but no template image
+     / mask pair are explicitly nominated at the command-line.
+
+.. option:: Dwi2maskTemplateMask
+
+    *default: (none)*
+
+     The template brain mask to utilise by default whenever the "dwi2mask
+     ants" or "dwi2mask template" algorithms are invoked but no template
+     image / mask pair are explicitly nominated at the command-line.
+
 .. option:: FailOnWarn
 
     *default: 0 (false)*

--- a/lib/mrtrix3/dwi2mask/ants.py
+++ b/lib/mrtrix3/dwi2mask/ants.py
@@ -35,13 +35,19 @@ def usage(base_parser, subparsers): #pylint: disable=unused-variable
 
 
 def get_inputs(): #pylint: disable=unused-variable
-  if not app.ARGS.template:
-    raise MRtrixError('For "ants" dwi2mask algorithm, '
-                      '-template command-line option is currently mandatory')
-  run.command('mrconvert ' + app.ARGS.template[0] + ' ' + path.to_scratch('template_image.nii')
-              + ' -strides +1,+2,+3')
-  run.command('mrconvert ' + app.ARGS.template[1] + ' ' + path.to_scratch('template_mask.nii')
-              + ' -strides +1,+2,+3')
+  if app.ARGS.template:
+    run.command('mrconvert ' + app.ARGS.template[0] + ' ' + path.to_scratch('template_image.nii')
+                + ' -strides +1,+2,+3')
+    run.command('mrconvert ' + app.ARGS.template[1] + ' ' + path.to_scratch('template_mask.nii')
+                + ' -strides +1,+2,+3 -datatype uint8')
+  elif all(item in CONFIG for item in ['Dwi2maskTemplateImage', 'Dwi2maskTemplateMask']):
+    run.command('mrconvert ' + CONFIG['Dwi2maskTemplateImage'] + ' ' + path.to_scratch('template_image.nii')
+                + ' -strides +1,+2,+3')
+    run.command('mrconvert ' + CONFIG['Dwi2maskTemplateMask'] + ' ' + path.to_scratch('template_mask.nii')
+                + ' -strides +1,+2,+3 -datatype uint8')
+  else:
+    raise MRtrixError('No template image information available from '
+                      'either command-line or MRtrix configuration file(s)')
 
 
 

--- a/lib/mrtrix3/dwi2mask/consensus.py
+++ b/lib/mrtrix3/dwi2mask/consensus.py
@@ -56,7 +56,7 @@ def execute(): #pylint: disable=unused-variable
     app.check_output_path(path.from_user(app.ARGS.masks, False))
 
   algorithm_list = [item for item in algorithm.get_list() if item != 'consensus']
-  app.var(algorithm_list)
+  app.debug(str(algorithm_list))
 
   if app.ARGS.algorithms:
     if 'consensus' in app.ARGS.algorithms:
@@ -75,7 +75,7 @@ def execute(): #pylint: disable=unused-variable
   algorithm_list = [item for item in algorithm_list if item != 'template']
   algorithm_list.append('template -software ants')
   algorithm_list.append('template -software fsl')
-  app.var(algorithm_list)
+  app.debug(str(algorithm_list))
 
   mask_list = []
   for alg in algorithm_list:
@@ -92,7 +92,7 @@ def execute(): #pylint: disable=unused-variable
       app.warn('"dwi2mask ' + alg + '" failed; will be omitted from consensus')
       app.debug(str(e_dwi2mask))
 
-  app.var(mask_list)
+  app.debug(str(mask_list))
   if not mask_list:
     raise MRtrixError('No dwi2mask algorithms were successful; cannot generate mask')
   if len(mask_list) == 1:
@@ -100,6 +100,7 @@ def execute(): #pylint: disable=unused-variable
     final_mask = mask_list[0]
   else:
     final_mask = 'consensus.mif'
+    app.console('Computing consensus from ' + str(len(mask_list)) + ' of ' + str(len(algorithm_list)) + ' algorithms')
     run.command(['mrmath', mask_list, 'mean', '-', '|',
                  'mrthreshold', '-', '-abs', '0.5', '-comparison', 'gt', final_mask])
 

--- a/lib/mrtrix3/dwi2mask/consensus.py
+++ b/lib/mrtrix3/dwi2mask/consensus.py
@@ -30,13 +30,19 @@ def usage(base_parser, subparsers): #pylint: disable=unused-variable
 
 
 def get_inputs(): #pylint: disable=unused-variable
-  if not app.ARGS.template:
-    raise MRtrixError('For "consensus" dwi2mask algorithm, '
-                      '-template command-line option is currently mandatory')
-  run.command('mrconvert ' + app.ARGS.template[0] + ' ' + path.to_scratch('template_image.nii')
-              + ' -strides +1,+2,+3')
-  run.command('mrconvert ' + app.ARGS.template[1] + ' ' + path.to_scratch('template_mask.nii')
-              + ' -strides +1,+2,+3')
+  if app.ARGS.template:
+    run.command('mrconvert ' + app.ARGS.template[0] + ' ' + path.to_scratch('template_image.nii')
+                + ' -strides +1,+2,+3')
+    run.command('mrconvert ' + app.ARGS.template[1] + ' ' + path.to_scratch('template_mask.nii')
+                + ' -strides +1,+2,+3 -datatype uint8')
+  elif all(item in CONFIG for item in ['Dwi2maskTemplateImage', 'Dwi2maskTemplateMask']):
+    run.command('mrconvert ' + CONFIG['Dwi2maskTemplateImage'] + ' ' + path.to_scratch('template_image.nii')
+                + ' -strides +1,+2,+3')
+    run.command('mrconvert ' + CONFIG['Dwi2maskTemplateMask'] + ' ' + path.to_scratch('template_mask.nii')
+                + ' -strides +1,+2,+3 -datatype uint8')
+  else:
+    raise MRtrixError('No template image information available from '
+                      'either command-line or MRtrix configuration file(s)')
 
 
 

--- a/lib/mrtrix3/dwi2mask/template.py
+++ b/lib/mrtrix3/dwi2mask/template.py
@@ -15,7 +15,7 @@
 
 import os
 from distutils.spawn import find_executable
-from mrtrix3 import MRtrixError
+from mrtrix3 import CONFIG, MRtrixError
 from mrtrix3 import app, fsl, path, run
 
 SOFTWARES = ['ants', 'fsl']
@@ -44,13 +44,19 @@ def usage(base_parser, subparsers): #pylint: disable=unused-variable
 
 
 def get_inputs(): #pylint: disable=unused-variable
-  if not app.ARGS.template:
-    raise MRtrixError('For "template" dwi2mask algorithm, '
-                      '-template command-line option is currently mandatory')
-  run.command('mrconvert ' + app.ARGS.template[0] + ' ' + path.to_scratch('template_image.nii')
-              + ' -strides +1,+2,+3')
-  run.command('mrconvert ' + app.ARGS.template[1] + ' ' + path.to_scratch('template_mask.nii')
-              + ' -strides +1,+2,+3')
+  if app.ARGS.template:
+    run.command('mrconvert ' + app.ARGS.template[0] + ' ' + path.to_scratch('template_image.nii')
+                + ' -strides +1,+2,+3')
+    run.command('mrconvert ' + app.ARGS.template[1] + ' ' + path.to_scratch('template_mask.nii')
+                + ' -strides +1,+2,+3 -datatype uint8')
+  elif all(item in CONFIG for item in ['Dwi2maskTemplateImage', 'Dwi2maskTemplateMask']):
+    run.command('mrconvert ' + CONFIG['Dwi2maskTemplateImage'] + ' ' + path.to_scratch('template_image.nii')
+                + ' -strides +1,+2,+3')
+    run.command('mrconvert ' + CONFIG['Dwi2maskTemplateMask'] + ' ' + path.to_scratch('template_mask.nii')
+                + ' -strides +1,+2,+3 -datatype uint8')
+  else:
+    raise MRtrixError('No template image information available from '
+                      'either command-line or MRtrix configuration file(s)')
 
 
 


### PR DESCRIPTION
The `dwi2mask` command is executed within some other *MRtrix3* scripts. Now that it is implemented as a Python script with multiple algorithms to select from, it is necessary to be able to influence which `dwi2mask` algorithm is used whenever it is invoked from inside one of these scripts (and therefore the user does not have access via the command-line).