### PR TITLE
[ENH] dwi2mask template: Enhancements

### DIFF
--- a/core/file/pyconfig.h
+++ b/core/file/pyconfig.h
@@ -46,6 +46,31 @@
 //CONF ants" or "dwi2mask template" algorithms are invoked but no template
 //CONF image / mask pair are explicitly nominated at the command-line.
 
+//CONF option: Dwi2maskTemplateANTsFullOptions
+//CONF default: (none)
+//CONF When dwi2mask template is used with -software antsfull (or
+//CONF Dwi2maskTemplate is set to "antsfull"), specify the command-line
+//CONF options with which command "antsRegistration" will be provided.
+
+//CONF option: Dwi2maskTemplateANTsQuickOptions
+//CONF default: (none)
+//CONF When dwi2mask template is used with -software antsquick (or
+//CONF Dwi2maskTemplate is set to "antsquick"), specify the command-line
+//CONF options with which command "antsRegistrationSynQuick.sh" will be
+//CONF provided.
+
+//CONF option: Dwi2maskTemplateFSLFlirtOptions
+//CONF default: (none)
+//CONF When dwi2mask template is used with -software fsl (or
+//CONF Dwi2maskTemplate is set to "fsl"), specify the command-line
+//CONF options with which FSL command flirt will be provided.
+
+//CONF option: Dwi2maskTemplateFSLFnirtConfig
+//CONF default: (none)
+//CONF When dwi2mask template is used with -software fsl (or
+//CONF Dwi2maskTemplate is set to "fsl"), specify the configuration
+//CONF file to be provided to the FSL command fnirt.
+
 //CONF option: ScriptScratchDir
 //CONF default: `.`
 //CONF The location in which to generate the scratch directories to be

--- a/docs/dwi_preprocessing/masking.rst
+++ b/docs/dwi_preprocessing/masking.rst
@@ -168,6 +168,13 @@ could produce a population template *b=0* image based on one's own data, and
 manually define a mask on that template that could then subsequently be
 used for DWI masking.
 
+For all registration algorithms, there are ``dwi2mask`` command-line options
+available for fine-tuning the behaviour of the registration by passing
+command-line options down to the relevant command(s); further, it is possible
+to set such parameters within the MRtrix configuration file, which may be of
+particular use if configuration file option ``Dwi2maskAlgorithm`` is set to
+``template`` (see :ref:`dwi2mask_config`).
+
 ``dwi2mask trace``
 ^^^^^^^^^^^^^^^^^^
 
@@ -266,9 +273,9 @@ scenarios (see below).
 Configuration file options
 --------------------------
 
-There are *four* options that can be set within the *MRtrix3*
+There are many options that can be set within the *MRtrix3*
 :ref:`mrtrix_config` that directly influence the operation of the ``dwi2mask``
-command. These are included in the :ref:`config_file_options`, but are
+command. These are included in the :ref:`config_file_options` page, but are
 mentioned here also for discoverability:
 
 -  ``Dwi2maskAlgorithm``
@@ -308,6 +315,17 @@ mentioned here also for discoverability:
    ``dwi2mask template``. If the value of configuration file option
    "``Dwi2maskAlgorithm``" is "``ants``" or "``template``", then
    these two entries *must also* be specified.
+
+-  ``Dwi2maskTemplateANTsQuickOptions``, ``Dwi2maskTemplateANTsFullOptions``,
+   ``Dwi2maskTemplateFSLFlirtOptions`` and ``Dwi2maskTemplateFSLFnirtConfig``
+
+   These options allow full automated control over the parameters with which
+   the external neuroimaging software package registration commands are
+   executed. If one of the relevant ``dwi2mask template`` command-line options
+   is used explicitly (``-ants_options``, ``-flirt_options``, ``-fnirt_config``),
+   that information takes precedence; otherwise, if one of these configuration
+   file entries is set, that information will be propagated directly to the
+   relevant command.
 
 .. _AFNI: https://afni.nimh.nih.gov/
 .. _ANTs: http://stnava.github.io/ANTs/

--- a/docs/reference/commands/dwi2mask.rst
+++ b/docs/reference/commands/dwi2mask.rst
@@ -770,8 +770,22 @@ Description
 
 This script currently assumes that the template image provided via the -template option is T2-weighted, and can therefore be trivially registered to a mean b=0 image.
 
+Command-line option -ants_options can be used with either the "antsquick" or "antsfull" software options. In both cases, image dimensionality is assumed to be 3, and so this should be omitted from the user-specified options.The input can be either a string (encased in double-quotes if more than one option is specified), or a path to a text file containing the requested options. In the case of the "antsfull" software option, one will require the names of the fixed and moving images that are provided to the antsRegistration command: these are "template_image.nii" and "bzero.nii" respectively.
+
 Options
 -------
+
+Options applicable when using the FSL software for registration
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- **-flirt_options " FlirtOptions"** Command-line options to pass to the FSL flirt command (provide a string within quotation marks that contains at least one space, even if only passing a single command-line option to flirt)
+
+- **-fnirt_config FILE** Specify a FNIRT configuration file for registration
+
+Options applicable when using the ANTs software for registration
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- **-ants_options** Provide options to be passed to the ANTs registration command (see Description)
 
 Options specific to the "template" algorithm
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/reference/commands/dwi2mask.rst
+++ b/docs/reference/commands/dwi2mask.rst
@@ -15,7 +15,7 @@ Usage
 
     dwi2mask algorithm [ options ] ...
 
--  *algorithm*: Select the algorithm to be used to complete the script operation; additional details and options become available once an algorithm is nominated. Options are: 3dautomask, ants, consensus, fslbet, hdbet, legacy, mean, template, trace
+-  *algorithm*: Select the algorithm to be used to complete the script operation; additional details and options become available once an algorithm is nominated. Options are: 3dautomask, ants, b02template, consensus, fslbet, hdbet, legacy, mean, trace
 
 Description
 -----------
@@ -264,6 +264,120 @@ References
 ^^^^^^^^^^
 
 * B. Avants, N.J. Tustison, G. Song, P.A. Cook, A. Klein, J.C. Jee. A reproducible evaluation of ANTs similarity metric performance in brain image registration. NeuroImage, 2011, 54, 2033-2044
+
+Tournier, J.-D.; Smith, R. E.; Raffelt, D.; Tabbara, R.; Dhollander, T.; Pietsch, M.; Christiaens, D.; Jeurissen, B.; Yeh, C.-H. & Connelly, A. MRtrix3: A fast, flexible and open software framework for medical image processing and visualisation. NeuroImage, 2019, 202, 116137
+
+--------------
+
+
+
+**Author:** Robert E. Smith (robert.smith@florey.edu.au)
+
+**Copyright:** Copyright (c) 2008-2020 the MRtrix3 contributors.
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+Covered Software is provided under this License on an "as is"
+basis, without warranty of any kind, either expressed, implied, or
+statutory, including, without limitation, warranties that the
+Covered Software is free of defects, merchantable, fit for a
+particular purpose or non-infringing.
+See the Mozilla Public License v. 2.0 for more details.
+
+For more details, see http://www.mrtrix.org/.
+
+.. _dwi2mask_b02template:
+
+dwi2mask b02template
+====================
+
+Synopsis
+--------
+
+Register the mean b=0 image to a T2-weighted template to back-propagate a brain mask
+
+Usage
+-----
+
+::
+
+    dwi2mask b02template input output [ options ]
+
+-  *input*: The input DWI series
+-  *output*: The output mask image
+
+Description
+-----------
+
+This script currently assumes that the template image provided via the -template option is T2-weighted, and can therefore be trivially registered to a mean b=0 image.
+
+Command-line option -ants_options can be used with either the "antsquick" or "antsfull" software options. In both cases, image dimensionality is assumed to be 3, and so this should be omitted from the user-specified options.The input can be either a string (encased in double-quotes if more than one option is specified), or a path to a text file containing the requested options. In the case of the "antsfull" software option, one will require the names of the fixed and moving images that are provided to the antsRegistration command: these are "template_image.nii" and "bzero.nii" respectively.
+
+Options
+-------
+
+Options applicable when using the FSL software for registration
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- **-flirt_options " FlirtOptions"** Command-line options to pass to the FSL flirt command (provide a string within quotation marks that contains at least one space, even if only passing a single command-line option to flirt)
+
+- **-fnirt_config FILE** Specify a FNIRT configuration file for registration
+
+Options applicable when using the ANTs software for registration
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- **-ants_options** Provide options to be passed to the ANTs registration command (see Description)
+
+Options specific to the "template" algorithm
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- **-software** The software to use for template registration; options are: antsfull,antsquick,fsl; default is antsquick
+
+- **-template TemplateImage MaskImage** Provide the template image to which the input data will be registered, and the mask to be projected to the input image. The template image should be T2-weighted.
+
+Options for importing the diffusion gradient table
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- **-grad** Provide the diffusion gradient table in MRtrix format
+
+- **-fslgrad bvecs bvals** Provide the diffusion gradient table in FSL bvecs/bvals format
+
+Additional standard options for Python scripts
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- **-nocleanup** do not delete intermediate files during script execution, and do not delete scratch directory at script completion.
+
+- **-scratch /path/to/scratch/** manually specify the path in which to generate the scratch directory.
+
+- **-continue <ScratchDir> <LastFile>** continue the script from a previous execution; must provide the scratch directory path, and the name of the last successfully-generated file.
+
+Standard options
+^^^^^^^^^^^^^^^^
+
+- **-info** display information messages.
+
+- **-quiet** do not display information messages or progress status. Alternatively, this can be achieved by setting the MRTRIX_QUIET environment variable to a non-empty string.
+
+- **-debug** display debugging messages.
+
+- **-force** force overwrite of output files.
+
+- **-nthreads number** use this number of threads in multi-threaded applications (set to 0 to disable multi-threading).
+
+- **-config key value**  *(multiple uses permitted)* temporarily set the value of an MRtrix config file entry.
+
+- **-help** display this information page and exit.
+
+- **-version** display version information and exit.
+
+References
+^^^^^^^^^^
+
+* If FSL software is used for registration: M. Jenkinson, C.F. Beckmann, T.E. Behrens, M.W. Woolrich, S.M. Smith. FSL. NeuroImage, 62:782-90, 2012
+
+* If ANTs software is used for registration: B. Avants, N.J. Tustison, G. Song, P.A. Cook, A. Klein, J.C. Jee. A reproducible evaluation of ANTs similarity metric performance in brain image registration. NeuroImage, 2011, 54, 2033-2044
 
 Tournier, J.-D.; Smith, R. E.; Raffelt, D.; Tabbara, R.; Dhollander, T.; Pietsch, M.; Christiaens, D.; Jeurissen, B.; Yeh, C.-H. & Connelly, A. MRtrix3: A fast, flexible and open software framework for medical image processing and visualisation. NeuroImage, 2019, 202, 116137
 
@@ -729,120 +843,6 @@ Tournier, J.-D.; Smith, R. E.; Raffelt, D.; Tabbara, R.; Dhollander, T.; Pietsch
 
 
 **Author:** Warda Syeda (wtsyeda@unimelb.edu.au)
-
-**Copyright:** Copyright (c) 2008-2020 the MRtrix3 contributors.
-
-This Source Code Form is subject to the terms of the Mozilla Public
-License, v. 2.0. If a copy of the MPL was not distributed with this
-file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-Covered Software is provided under this License on an "as is"
-basis, without warranty of any kind, either expressed, implied, or
-statutory, including, without limitation, warranties that the
-Covered Software is free of defects, merchantable, fit for a
-particular purpose or non-infringing.
-See the Mozilla Public License v. 2.0 for more details.
-
-For more details, see http://www.mrtrix.org/.
-
-.. _dwi2mask_template:
-
-dwi2mask template
-=================
-
-Synopsis
---------
-
-Register the mean b=0 image to a T2-weighted template to back-propagate a brain mask
-
-Usage
------
-
-::
-
-    dwi2mask template input output [ options ]
-
--  *input*: The input DWI series
--  *output*: The output mask image
-
-Description
------------
-
-This script currently assumes that the template image provided via the -template option is T2-weighted, and can therefore be trivially registered to a mean b=0 image.
-
-Command-line option -ants_options can be used with either the "antsquick" or "antsfull" software options. In both cases, image dimensionality is assumed to be 3, and so this should be omitted from the user-specified options.The input can be either a string (encased in double-quotes if more than one option is specified), or a path to a text file containing the requested options. In the case of the "antsfull" software option, one will require the names of the fixed and moving images that are provided to the antsRegistration command: these are "template_image.nii" and "bzero.nii" respectively.
-
-Options
--------
-
-Options applicable when using the FSL software for registration
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-- **-flirt_options " FlirtOptions"** Command-line options to pass to the FSL flirt command (provide a string within quotation marks that contains at least one space, even if only passing a single command-line option to flirt)
-
-- **-fnirt_config FILE** Specify a FNIRT configuration file for registration
-
-Options applicable when using the ANTs software for registration
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-- **-ants_options** Provide options to be passed to the ANTs registration command (see Description)
-
-Options specific to the "template" algorithm
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-- **-software** The software to use for template registration; options are: antsfull,antsquick,fsl; default is antsquick
-
-- **-template TemplateImage MaskImage** Provide the template image to which the input data will be registered, and the mask to be projected to the input image. The template image should be T2-weighted.
-
-Options for importing the diffusion gradient table
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-- **-grad** Provide the diffusion gradient table in MRtrix format
-
-- **-fslgrad bvecs bvals** Provide the diffusion gradient table in FSL bvecs/bvals format
-
-Additional standard options for Python scripts
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-- **-nocleanup** do not delete intermediate files during script execution, and do not delete scratch directory at script completion.
-
-- **-scratch /path/to/scratch/** manually specify the path in which to generate the scratch directory.
-
-- **-continue <ScratchDir> <LastFile>** continue the script from a previous execution; must provide the scratch directory path, and the name of the last successfully-generated file.
-
-Standard options
-^^^^^^^^^^^^^^^^
-
-- **-info** display information messages.
-
-- **-quiet** do not display information messages or progress status. Alternatively, this can be achieved by setting the MRTRIX_QUIET environment variable to a non-empty string.
-
-- **-debug** display debugging messages.
-
-- **-force** force overwrite of output files.
-
-- **-nthreads number** use this number of threads in multi-threaded applications (set to 0 to disable multi-threading).
-
-- **-config key value**  *(multiple uses permitted)* temporarily set the value of an MRtrix config file entry.
-
-- **-help** display this information page and exit.
-
-- **-version** display version information and exit.
-
-References
-^^^^^^^^^^
-
-* If FSL software is used for registration: M. Jenkinson, C.F. Beckmann, T.E. Behrens, M.W. Woolrich, S.M. Smith. FSL. NeuroImage, 62:782-90, 2012
-
-* If ANTs software is used for registration: B. Avants, N.J. Tustison, G. Song, P.A. Cook, A. Klein, J.C. Jee. A reproducible evaluation of ANTs similarity metric performance in brain image registration. NeuroImage, 2011, 54, 2033-2044
-
-Tournier, J.-D.; Smith, R. E.; Raffelt, D.; Tabbara, R.; Dhollander, T.; Pietsch, M.; Christiaens, D.; Jeurissen, B.; Yeh, C.-H. & Connelly, A. MRtrix3: A fast, flexible and open software framework for medical image processing and visualisation. NeuroImage, 2019, 202, 116137
-
---------------
-
-
-
-**Author:** Robert E. Smith (robert.smith@florey.edu.au)
 
 **Copyright:** Copyright (c) 2008-2020 the MRtrix3 contributors.
 

--- a/docs/reference/config_file_options.rst
+++ b/docs/reference/config_file_options.rst
@@ -221,6 +221,39 @@ List of MRtrix3 configuration file options
      within a Python script, and the user is not provided with the
      opportunity to select the algorithm at the command-line.
 
+.. option:: Dwi2maskTemplateANTsFullOptions
+
+    *default: (none)*
+
+     When dwi2mask template is used with -software antsfull (or
+     Dwi2maskTemplate is set to "antsfull"), specify the command-line
+     options with which command "antsRegistration" will be provided.
+
+.. option:: Dwi2maskTemplateANTsQuickOptions
+
+    *default: (none)*
+
+     When dwi2mask template is used with -software antsquick (or
+     Dwi2maskTemplate is set to "antsquick"), specify the command-line
+     options with which command "antsRegistrationSynQuick.sh" will be
+     provided.
+
+.. option:: Dwi2maskTemplateFSLFlirtOptions
+
+    *default: (none)*
+
+     When dwi2mask template is used with -software fsl (or
+     Dwi2maskTemplate is set to "fsl"), specify the command-line
+     options with which FSL command flirt will be provided.
+
+.. option:: Dwi2maskTemplateFSLFnirtConfig
+
+    *default: (none)*
+
+     When dwi2mask template is used with -software fsl (or
+     Dwi2maskTemplate is set to "fsl"), specify the configuration
+     file to be provided to the FSL command fnirt.
+
 .. option:: Dwi2maskTemplateImage
 
     *default: (none)*

--- a/lib/mrtrix3/dwi2mask/b02template.py
+++ b/lib/mrtrix3/dwi2mask/b02template.py
@@ -51,7 +51,7 @@ ANTS_REGISTERQUICK_OPTIONS = '-j 1'
 
 
 def usage(base_parser, subparsers): #pylint: disable=unused-variable
-  parser = subparsers.add_parser('template', parents=[base_parser])
+  parser = subparsers.add_parser('b02template', parents=[base_parser])
   parser.set_author('Robert E. Smith (robert.smith@florey.edu.au)')
   parser.set_synopsis('Register the mean b=0 image to a T2-weighted template to back-propagate a brain mask')
   parser.add_description('This script currently assumes that the template image provided via the -template option '

--- a/lib/mrtrix3/dwi2mask/consensus.py
+++ b/lib/mrtrix3/dwi2mask/consensus.py
@@ -119,7 +119,7 @@ def execute(): #pylint: disable=unused-variable
   app.console('Computing consensus from ' + str(len(mask_list)) + ' of ' + str(len(algorithm_list)) + ' algorithms')
   run.command(['mrcat', mask_list, '-axis', '3', 'all_masks.mif'])
   run.command('mrmath all_masks.mif mean - -axis 3 | '
-              'mrthreshold - -abs ' + app.ARGS.threshold + ' -comparison ge ' + final_mask)
+              'mrthreshold - -abs ' + str(app.ARGS.threshold) + ' -comparison ge ' + final_mask)
 
   if app.ARGS.masks:
     run.command('mrconvert all_masks.mif ' + path.from_user(app.ARGS.masks),

--- a/lib/mrtrix3/dwi2mask/template.py
+++ b/lib/mrtrix3/dwi2mask/template.py
@@ -146,7 +146,7 @@ def execute(): #pylint: disable=unused-variable
       if os.path.isfile('ants_options.txt'):
         with open('ants_options.txt', 'r') as ants_options_file:
           ants_options = ants_options_file.readlines()
-        ants_options = ' '.join(line.lstrip().rstrip(' \/') for line in ants_options if not line.lstrip()[0] == '#')
+        ants_options = ' '.join(line.lstrip().rstrip(' \/') for line in ants_options if line and not line.lstrip()[0] == '#')
       else:
         ants_options = app.ARGS.ants_options
     else:
@@ -165,7 +165,7 @@ def execute(): #pylint: disable=unused-variable
       ants_options_split = ants_options.split()
       nonlinear = any(i for i in range(0, len(ants_options_split)-1)
                       if ants_options_split[i] == '--transform'
-                      and not any(item in ants_options_split[i+1] for item in ['Rigid', 'Affine']))
+                      and not any(item in ants_options_split[i+1] for item in ['Rigid', 'Affine', 'Translation']))
     else:
       # Use ANTs SyNQuick for registration to template
       run.command(ANTS_REGISTERQUICK_CMD
@@ -175,7 +175,10 @@ def execute(): #pylint: disable=unused-variable
                   + ' -o ANTS'
                   + ' '
                   + ants_options)
-      nonlinear = True
+      ants_options_split = ants_options.split()
+      nonlinear = not any(i for i in range(0, len(ants_options_split)-1)
+                          if ants_options_split[i] == '-t'
+                          and ants_options_split[i+1] in ['t', 'r', 'a'])
 
     transformed_path = 'transformed.nii'
     # Note: Don't use nearest-neighbour interpolation;

--- a/lib/mrtrix3/dwi2mask/template.py
+++ b/lib/mrtrix3/dwi2mask/template.py
@@ -146,7 +146,7 @@ def execute(): #pylint: disable=unused-variable
       if os.path.isfile('ants_options.txt'):
         with open('ants_options.txt', 'r') as ants_options_file:
           ants_options = ants_options_file.readlines()
-        ants_options = ' '.join(line.lstrip().rstrip(' \/') for line in ants_options if line.strip() and not line.lstrip()[0] == '#')
+        ants_options = ' '.join(line.lstrip().rstrip('\n \/') for line in ants_options if line.strip() and not line.lstrip()[0] == '#')
       else:
         ants_options = app.ARGS.ants_options
     else:

--- a/lib/mrtrix3/dwi2mask/template.py
+++ b/lib/mrtrix3/dwi2mask/template.py
@@ -217,8 +217,13 @@ def execute(): #pylint: disable=unused-variable
                 'mrconvert - template_mask_dilated.nii -datatype uint8')
 
     # Non-linear registration to template
+    if os.path.isfile('fnirt_config.cnf'):
+      fnirt_config_option = ' --config=fnirt_config'
+    else:
+      fnirt_config_option = ''
+      app.console('No config file provided for FSL fnirt; it will use its internal defaults')
     run.command(fnirt_cmd
-                + (' --config=fnirt_config' if os.path.isfile('fnirt_config.cnf') else '')
+                + fnirt_config_option
                 + ' --ref=template_image.nii'
                 + ' --refmask=template_mask_dilated.nii'
                 + ' --in=bzero.nii'

--- a/lib/mrtrix3/dwi2mask/template.py
+++ b/lib/mrtrix3/dwi2mask/template.py
@@ -146,7 +146,7 @@ def execute(): #pylint: disable=unused-variable
       if os.path.isfile('ants_options.txt'):
         with open('ants_options.txt', 'r') as ants_options_file:
           ants_options = ants_options_file.readlines()
-        ants_options = ' '.join(line.lstrip().rstrip(' \/') for line in ants_options if line and not line.lstrip()[0] == '#')
+        ants_options = ' '.join(line.lstrip().rstrip(' \/') for line in ants_options if line.strip() and not line.lstrip()[0] == '#')
       else:
         ants_options = app.ARGS.ants_options
     else:
@@ -176,9 +176,9 @@ def execute(): #pylint: disable=unused-variable
                   + ' '
                   + ants_options)
       ants_options_split = ants_options.split()
-      nonlinear = not any(i for i in range(0, len(ants_options_split)-1)
-                          if ants_options_split[i] == '-t'
-                          and ants_options_split[i+1] in ['t', 'r', 'a'])
+      nonlinear = not [i for i in range(0, len(ants_options_split)-1)
+                       if ants_options_split[i] == '-t'
+                       and ants_options_split[i+1] in ['t', 'r', 'a']]
 
     transformed_path = 'transformed.nii'
     # Note: Don't use nearest-neighbour interpolation;

--- a/testing/scripts/tests/dwi2mask
+++ b/testing/scripts/tests/dwi2mask
@@ -9,9 +9,19 @@ dwi2mask fslbet tmp-sub-01_dwi.mif ../tmp/dwi2mask/fslbet_rescale.mif -rescale -
 dwi2mask hdbet tmp-sub-01_dwi.mif ../tmp/dwi2mask/hdbet.mif -force
 dwi2mask legacy tmp-sub-01_dwi.mif ../tmp/dwi2mask/legacy.mif -force && testing_diff_image ../tmp/dwi2mask/legacy.mif dwi2mask/legacy.mif.gz
 dwi2mask mean tmp-sub-01_dwi.mif ../tmp/dwi2mask/mean.mif -force && testing_diff_image ../tmp/dwi2mask/mean.mif dwi2mask/mean.mif.gz
-dwi2mask template tmp-sub-01_dwi.mif ../tmp/dwi2mask/template_antsfull.mif -software antsfull -template dwi2mask/template_image.mif.gz dwi2mask/template_mask.mif.gz -force
-dwi2mask template tmp-sub-01_dwi.mif ../tmp/dwi2mask/template_antsquick.mif -software antsquick -template dwi2mask/template_image.mif.gz dwi2mask/template_mask.mif.gz -force
-dwi2mask template tmp-sub-01_dwi.mif ../tmp/dwi2mask/template_fsl.mif -software fsl -template dwi2mask/template_image.mif.gz dwi2mask/template_mask.mif.gz -force
+dwi2mask template tmp-sub-01_dwi.mif ../tmp/dwi2mask/template_antsfull_default.mif -software antsfull -template dwi2mask/template_image.mif.gz dwi2mask/template_mask.mif.gz -force
+dwi2mask template tmp-sub-01_dwi.mif ../tmp/dwi2mask/template_antsquick_default.mif -software antsquick -template dwi2mask/template_image.mif.gz dwi2mask/template_mask.mif.gz -force
+dwi2mask template tmp-sub-01_dwi.mif ../tmp/dwi2mask/template_antsfull_cmdline.mif -software antsfull -template dwi2mask/template_image.mif.gz dwi2mask/template_mask.mif.gz -ants_options "--use-histogram-matching 1 --initial-moving-transform [template_image.nii,bzero.nii,1] --transform Rigid[0.1] --metric MI[template_image.nii,bzero.nii,1,32,Regular,0.25] --convergence 1000x500x250x100 --smoothing-sigmas 3x2x1x0 --shrink-factors 8x4x2x1" -force
+dwi2mask template tmp-sub-01_dwi.mif ../tmp/dwi2mask/template_antsfull_config.mif -software antsfull -template dwi2mask/template_image.mif.gz dwi2mask/template_mask.mif.gz -config Dwi2maskTemplateAntsFullOptions "--use-histogram-matching 1 --initial-moving-transform [template_image.nii,bzero.nii,1] --transform Rigid[0.1] --metric MI[template_image.nii,bzero.nii,1,32,Regular,0.25] --convergence 1000x500x250x100 --smoothing-sigmas 3x2x1x0 --shrink-factors 8x4x2x1" -force
+dwi2mask template tmp-sub-01_dwi.mif ../tmp/dwi2mask/template_antsfull_file1.mif -software antsfull -template dwi2mask/template_image.mif.gz dwi2mask/template_mask.mif.gz -ants_options dwi2mask/config_antsfull_1.txt -force
+dwi2mask template tmp-sub-01_dwi.mif ../tmp/dwi2mask/template_antsfull_file2.mif -software antsfull -template dwi2mask/template_image.mif.gz dwi2mask/template_mask.mif.gz -ants_options dwi2mask/config_antsfull_2.txt -force
+dwi2mask template tmp-sub-01_dwi.mif ../tmp/dwi2mask/template_antsquick_cmdline.mif -software antsquick -template dwi2mask/template_image.mif.gz dwi2mask/template_mask.mif.gz -ants_options "-t r" -force
+dwi2mask template tmp-sub-01_dwi.mif ../tmp/dwi2mask/template_antsquick_config.mif -software antsquick -template dwi2mask/template_image.mif.gz dwi2mask/template_mask.mif.gz -config Dwi2maskTemplateANTsQuickOptions "-t r" -force
+dwi2mask template tmp-sub-01_dwi.mif ../tmp/dwi2mask/template_fsl_default.mif -software fsl -template dwi2mask/template_image.mif.gz dwi2mask/template_mask.mif.gz -force
+dwi2mask template tmp-sub-01_dwi.mif ../tmp/dwi2mask/template_fsl_flirtcmdline.mif -software fsl -template dwi2mask/template_image.mif.gz dwi2mask/template_mask.mif.gz -flirt_options "-cost normmi -dof 12" -force
+dwi2mask template tmp-sub-01_dwi.mif ../tmp/dwi2mask/template_fsl_flirtconfig.mif -software fsl -template dwi2mask/template_image.mif.gz dwi2mask/template_mask.mif.gz -config Dwi2maskTemplateFSLFlirtOptions "-cost normmi -dof 12" -force
+dwi2mask template tmp-sub-01_dwi.mif ../tmp/dwi2mask/template_fsl_fnirtcmdline.mif -software fsl -template dwi2mask/template_image.mif.gz dwi2mask/template_mask.mif.gz -fnirt_config dwi2mask/fnirt_config.cnf -force
+dwi2mask template tmp-sub-01_dwi.mif ../tmp/dwi2mask/template_fsl_fnirtconfig.mif -software fsl -template dwi2mask/template_image.mif.gz dwi2mask/template_mask.mif.gz -config Dwi2maskTemplateFSLFnirtConfig $(pwd)/dwi2mask/fnirt_config.cnf -force
 dwi2mask trace tmp-sub-01_dwi.mif ../tmp/dwi2mask/trace_default.mif -force && testing_diff_image ../tmp/dwi2mask/trace_default.mif dwi2mask/trace_default.mif.gz
 dwi2mask trace tmp-sub-01_dwi.mif ../tmp/dwi2mask/trace_iterative.mif -iterative -force && testing_diff_image ../tmp/dwi2mask/trace_iterative.mif dwi2mask/trace_iterative.mif.gz
 

--- a/testing/scripts/tests/dwi2mask
+++ b/testing/scripts/tests/dwi2mask
@@ -1,7 +1,7 @@
 mkdir -p ../tmp/dwi2mask && mrconvert BIDS/sub-01/dwi/sub-01_dwi.nii.gz -fslgrad BIDS/sub-01/dwi/sub-01_dwi.bvec BIDS/sub-01/dwi/sub-01_dwi.bval tmp-sub-01_dwi.mif -force && dwi2mask 3dautomask tmp-sub-01_dwi.mif ../tmp/dwi2mask/3dautomask_default.mif
 dwi2mask 3dautomask tmp-sub-01_dwi.mif ../tmp/dwi2mask/3dautomask_options.mif -clfrac 0.5 -nograd -peels 1 -nbhrs 17 -eclip -SI 130 -dilate 0 -erode 0 -NN1 -NN2 -NN3
-dwi2mask ants tmp-sub-01_dwi.mif ../tmp/dwi2mask/ants.mif -template dwi2mask/template_image.mif.gz dwi2mask/template_mask.mif.gz -force
-dwi2mask ants tmp-sub-01_dwi.mif ../tmp/dwi2mask/ants.mif -config Dwi2maskTemplateImage dwi2mask/template_image.mif.gz -config Dwi2maskTemplateMask dwi2mask/template_mask.mif.gz -force
+dwi2mask ants tmp-sub-01_dwi.mif ../tmp/dwi2mask/ants_default.mif -template dwi2mask/template_image.mif.gz dwi2mask/template_mask.mif.gz -force
+dwi2mask ants tmp-sub-01_dwi.mif ../tmp/dwi2mask/ants_config.mif -config Dwi2maskTemplateImage dwi2mask/template_image.mif.gz -config Dwi2maskTemplateMask dwi2mask/template_mask.mif.gz -force
 dwi2mask consensus tmp-sub-01_dwi.mif ../tmp/dwi2mask/consensus_output.mif -masks ../tmp/dwi2mask/consensus_masks.mif -template dwi2mask/template_image.mif.gz dwi2mask/template_mask.mif.gz -force
 dwi2mask fslbet tmp-sub-01_dwi.mif ../tmp/dwi2mask/fslbet_default.mif -force
 dwi2mask fslbet tmp-sub-01_dwi.mif ../tmp/dwi2mask/fslbet_options.mif -bet_f 0.5 -bet_g 0.0 -bet_c 14 18 16 -bet_r 130.0 -force


### PR DESCRIPTION
Pinging @jdtournier @maxpietsch @dchristiaens @bjeurissen since it was discussed during our meeting but changes are on my fork. Listing changes separately here so as not to get lost in the volume of changes in MRtrix3/mrtrix3#2197.

This provides the user with the ability to set registration parameters within the `dwi2mask template` algorithm. Further, because `dwi2mask` may be called from within Python scripts, those parameters can be set via the configuration file.

Also, regarding `dwi2mask template -software fsl`: it's been left in place, but I've reverted it to *not* provide `fnirt` with FSL's T1-to-MNI normalisation configuration file, and therefore just use its internal default parameters; the user also now has the ability to either specify one of the existing configuration files from FSL, or devise a new configuration file tailored for *b*=0-to-some-template registration and specify that. So I'm trying to stick with the deferral-of-responsibility approach, but with a wider door for someone sufficiently engaged / motivated to figure out a good group of settings for `fnirt` and hopefully offer to share.

One final variable I'll throw into the mix: If there's a future prospect of multi-contrast registration to a template being used for the purpose of brain masking, would this algorithm—which always uses the mean *b*=0 image only—be better named something like "`t2template`" / "`b02template`"?